### PR TITLE
allow context to be set

### DIFF
--- a/lib/handler.js
+++ b/lib/handler.js
@@ -17,8 +17,14 @@ if (GITHUB_API_ENDPOINT) {
   config.pathPrefix = url.parse(GITHUB_API_ENDPOINT).path;
 }
 
-module.exports = function (token, url, data, status, description) {
-  debug('Setting status', token, url, data, status, description)
+module.exports = function (token, url, data, status, description, context) {
+  debug('Setting status', token, url, data, status, description, context)
+  if(description === undefined) {
+    description = 'Strider test in progress';
+  }
+  if(context === undefined) {
+    context = 'strider-cd';
+  }
   var github = new GithubApi(config)
   github.authenticate({
     type: 'oauth',
@@ -30,7 +36,8 @@ module.exports = function (token, url, data, status, description) {
     repo: data.repo,
     state: status,
     sha: data.sha,
-    description: description
+    description: description,
+    context: context
   }, function (err) {
     if (err) console.error('failed to set github status', url, data, err.message)
   })

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "strider-github-status",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "Add build status indicators to pull requests in github",
   "main": "index.js",
   "repository": {
@@ -21,7 +21,7 @@
   },
   "homepage": "https://github.com/Strider-CD/strider-github-status",
   "dependencies": {
-    "github": "~0.1.12",
+    "github": "~0.2.4",
     "debug": "~0.7.4"
   },
   "publishConfig": {

--- a/package.json
+++ b/package.json
@@ -21,8 +21,8 @@
   },
   "homepage": "https://github.com/Strider-CD/strider-github-status",
   "dependencies": {
-    "github": "~0.2.4",
-    "debug": "~0.7.4"
+    "github": "^0.2.4",
+    "debug": "^2.2.0"
   },
   "publishConfig": {
     "registry": "http://registry.npmjs.org"

--- a/webapp.js
+++ b/webapp.js
@@ -13,12 +13,17 @@ function jobDescription(job) {
 }
 
 module.exports = {
+  config: {
+    pending.msg: String,
+    context: String,
+  }
+
   // global events
   listen: function (io, context) {
     io.on('plugin.github-status.started', function (jobId, projectName, token, data) {
       debug('got', jobId, projectName, token, data)
       var url = context.config.server_name + '/' + projectName + '/job/' + jobId
-      setStatus(token, url, data, 'pending', 'Strider test in progress')
+      setStatus(token, url, data, 'pending', config.pending_msg, config.context)
     })
 
     io.on('plugin.github-status.done', function (jobId, projectName, token, data) {
@@ -30,7 +35,7 @@ module.exports = {
         var url = context.config.server_name + '/' + projectName + '/job/' + jobId
           , status = jobStatus(job)
           , description = jobDescription(job)
-        setStatus(token, url, data, status, description)
+        setStatus(token, url, data, status, description, config.context)
       }
       io.on('job.doneAndSaved', onDoneAndSaved)
     })

--- a/webapp.js
+++ b/webapp.js
@@ -14,16 +14,16 @@ function jobDescription(job) {
 
 module.exports = {
   config: {
-    pending.msg: String,
-    context: String,
-  }
+    pendingMsg: String,
+    context: String
+  },
 
   // global events
-  listen: function (io, context) {
+  listen: function (io, context, config) {
     io.on('plugin.github-status.started', function (jobId, projectName, token, data) {
       debug('got', jobId, projectName, token, data)
       var url = context.config.server_name + '/' + projectName + '/job/' + jobId
-      setStatus(token, url, data, 'pending', config.pending_msg, config.context)
+      setStatus(token, url, data, 'pending', config.pendingMsg, config.context)
     })
 
     io.on('plugin.github-status.done', function (jobId, projectName, token, data) {


### PR DESCRIPTION
Allows the status context to be configured for the status plugin.
More details about status contexts may be found here: https://developer.github.com/changes/2014-03-27-combined-status-api/
